### PR TITLE
✨ 🐛 💄 

### DIFF
--- a/SMASH/components/Cards/Card.vue
+++ b/SMASH/components/Cards/Card.vue
@@ -14,7 +14,7 @@
             :src="imageLink"
             :alt="imageAlt || `Picture for ${title}`"
             class="w-full h-full min-h-[300px] max-h-[300px] object-scale-down"
-            quality="50"
+            quality="30"
           />
           <vue-tube
             v-if="videoId && !image"
@@ -33,7 +33,7 @@
           :style="!vueHorizontalChild ? 'min-height: 11rem' : ''"
         >
           <p
-            class="flex text-xs font-semibold tracking-wide text-gray-500 uppercase bg-teal-200 rounded-full "
+            class="flex text-xs font-semibold tracking-wide text-gray-500 uppercase bg-teal-200 rounded-full"
           >
             {{ new Date(date).toDateString() }}
           </p>

--- a/SMASH/components/Cards/HorizontalCard.vue
+++ b/SMASH/components/Cards/HorizontalCard.vue
@@ -3,56 +3,55 @@
     class="flex items-center max-w-6xl p-3 overflow-hidden rounded shadow-md min-w-20 justify-evenly"
     :href="link"
   >
-      <div
-        v-if="icon || image"
-        class="flex items-center justify-center w-1/2">
-          <Icon
-              v-if="icon"
-              :icon="icon"
-              class="w-10 h-10 text-gray-400 md:w-20 md:h-20"
-              aria-hidden="true"
-          />
-          <nuxt-img
-            v-if="imageLink"
-            :src="imageLink"
-            :alt="imageAlt || `Picture for ${text}`"
-            class="w-3/4 h-3/4 min-h-[300px] object-scale-down max-h-10 max-w-10"
-            quality="30"
-        />
-      </div>
-      <div class="flex-shrink-0 w-1/2 h-full p-2">
-          <slot>
-            <p class="text-base font-medium leading-tight text-left flex-grow-1 lg:text-xl md:text-lg">
-              {{text}}
-            </p>
-          </slot>
-      </div>
+    <div v-if="icon || image" class="flex items-center justify-center w-1/2">
+      <Icon
+        v-if="icon"
+        :icon="icon"
+        class="w-10 h-10 text-gray-400 md:w-20 md:h-20"
+        aria-hidden="true"
+      />
+      <nuxt-img
+        v-if="imageLink"
+        :src="imageLink"
+        :alt="imageAlt || `Picture for ${text}`"
+        class="w-3/4 h-3/4 min-h-[300px] object-scale-down max-h-10 max-w-10"
+        quality="30"
+      />
+    </div>
+    <div class="flex-shrink-0 w-1/2 h-full p-2">
+      <slot>
+        <p
+          class="text-base font-medium leading-tight text-left flex-grow-1 lg:text-xl md:text-lg"
+        >
+          {{ text }}
+        </p>
+      </slot>
+    </div>
   </a>
 </template>
-
 
 <script>
 import Icon from '@/components/Icon.vue'
 export default {
   name: 'HorizontalCard',
   components: {
-    Icon  
+    Icon,
   },
   props: {
     text: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
     icon: {
       type: String,
       required: false,
-      default: ''
+      default: '',
     },
     image: {
       type: String,
       required: false,
-      defalt: ''
+      default: '',
     },
     imageAlt: {
       type: String,

--- a/SMASH/components/Cards/HorizontalCard.vue
+++ b/SMASH/components/Cards/HorizontalCard.vue
@@ -17,7 +17,7 @@
             :src="imageLink"
             :alt="imageAlt || `Picture for ${text}`"
             class="w-3/4 h-3/4 min-h-[300px] object-scale-down max-h-10 max-w-10"
-            quality="50"
+            quality="30"
         />
       </div>
       <div class="flex-shrink-0 w-1/2 h-full p-2">

--- a/SMASH/components/Footer.vue
+++ b/SMASH/components/Footer.vue
@@ -12,6 +12,7 @@
           :key="icon.name"
           :href="icon.link"
           class="p-1 overflow-hidden rounded-md hover:bg-gray-400"
+          target="_blank"
         >
           <Icon
             :icon="icon.icon"

--- a/SMASH/components/Header/Header.vue
+++ b/SMASH/components/Header/Header.vue
@@ -2,7 +2,7 @@
   <header class="relative w-full bg-white">
     <div class="px-4 mx-auto max-w-7xl sm:px-6">
       <div
-        class="flex items-center justify-between py-6 border-b-2 border-gray-100  md:justify-start md:space-x-10"
+        class="flex items-center justify-between py-6 border-b-2 border-gray-100 md:justify-start md:space-x-10"
       >
         <div class="flex justify-start lg:w-0 lg:flex-1">
           <nuxt-link v-if="!onHome" to="/" class="flex items-center">
@@ -29,7 +29,7 @@
         <div id="first" class="-my-2 -mr-2 md:hidden">
           <button
             type="button"
-            class="inline-flex items-center justify-center p-2 text-gray-400 bg-white rounded-md  hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+            class="inline-flex items-center justify-center p-2 text-gray-400 bg-white rounded-md hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
             aria-expanded="false"
             @click="toggleMobileMenu"
           >
@@ -52,7 +52,7 @@
         <div class="items-center justify-end hidden md:flex md:flex-1 lg:w-0">
           <a
             :href="button.link"
-            class="inline-flex items-center justify-center px-4 py-2 ml-8 text-base font-medium text-white bg-black border border-transparent rounded-md shadow-sm  whitespace-nowrap hover:bg-indigo-700"
+            class="inline-flex items-center justify-center px-4 py-2 ml-8 text-base font-medium text-white bg-black border border-transparent rounded-md shadow-sm whitespace-nowrap hover:bg-indigo-700"
           >
             {{ button.title }}
           </a>
@@ -65,11 +65,11 @@
     -->
     <div
       v-if="mobileMenuOpen"
-      class="absolute inset-x-0 top-0 p-2 transition origin-top-right transform  md:hidden"
+      class="absolute inset-x-0 top-0 p-2 transition origin-top-right transform md:hidden"
       style="z-index: 80"
     >
       <div
-        class="bg-white divide-y-2 rounded-lg shadow-lg  ring-1 ring-black ring-opacity-5 divide-gray-50"
+        class="bg-white divide-y-2 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 divide-gray-50"
       >
         <div class="px-5 pt-5 pb-6">
           <div class="flex items-center justify-between">
@@ -87,7 +87,7 @@
             <div class="-mr-2">
               <button
                 type="button"
-                class="inline-flex items-center justify-center p-2 text-gray-400 bg-white rounded-md  hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+                class="inline-flex items-center justify-center p-2 text-gray-400 bg-white rounded-md hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
                 @click="closeMobileMenu"
               >
                 <span class="sr-only">Close menu</span>
@@ -102,7 +102,9 @@
           <div class="mt-6 ml-1">
             <nav class="grid gap-y-8" role="navigation">
               <a
-                v-for="navMenuRowItem in mobileNavMenuItems.rowItems"
+                v-for="navMenuRowItem in mobileNavMenuItems.rowItems.filter(
+                  (item) => item.link.split('/')[1] != 'projects'
+                )"
                 :key="navMenuRowItem.title"
                 :href="navMenuRowItem.link"
                 class="flex items-center p-3 -m-3 rounded-md hover:bg-gray-50"
@@ -141,7 +143,7 @@
           <div>
             <a
               :href="button.link"
-              class="flex items-center justify-center w-full px-4 py-2 text-base font-medium text-white bg-black border border-transparent rounded-md shadow-sm  hover:bg-indigo-700"
+              class="flex items-center justify-center w-full px-4 py-2 text-base font-medium text-white bg-black border border-transparent rounded-md shadow-sm hover:bg-indigo-700"
             >
               {{ button.title }}
             </a>

--- a/SMASH/components/Header/Header.vue
+++ b/SMASH/components/Header/Header.vue
@@ -14,7 +14,7 @@
               width="40"
               :src="image"
               alt="SMASH Logo"
-              quality="50"
+              quality="30"
             />
             <abbr
               v-if="!onHome"
@@ -80,6 +80,7 @@
                 class="w-auto h-8"
                 :src="image"
                 alt="SMASH Logo"
+                quality="30"
               />
               <p class="text-lg font-bold tracking-wider">SMASH</p>
             </nuxt-link>

--- a/SMASH/components/Index/index-title.vue
+++ b/SMASH/components/Index/index-title.vue
@@ -9,6 +9,7 @@
           width="266"
           :src="imageLink"
           alt="SMASH Logo"
+          quality="30"
         />
       </div>
 

--- a/SMASH/content/core/footer.yaml
+++ b/SMASH/content/core/footer.yaml
@@ -1,1 +1,1 @@
-footerText: "**SMASH 2021**"
+footerText: '**SMASH 2022**'

--- a/SMASH/content/publications/fri-oct-08-2021-10-28-03-gmt-0400-eastern-daylight-time-list-dr-taylor-oshan.yml
+++ b/SMASH/content/publications/fri-oct-08-2021-10-28-03-gmt-0400-eastern-daylight-time-list-dr-taylor-oshan.yml
@@ -1,6 +1,6 @@
-title: "Sauer, J., Oshan, T., Rey, S., & Wolf, L. J. (2021). The Importance of
+title: 'Sauer, J., Oshan, T., Rey, S., & Wolf, L. J. (2021). The Importance of
   Null Hypotheses: Understanding Differences in Local Moran’s under
-  Heteroskedasticity. Geographical Analysis."
+  Heteroskedasticity. Geographical Analysis.'
 file: https://osf.io/ugkhp
 link: https://onlinelibrary.wiley.com/doi/abs/10.1111/gean.12304?__cf_chl_jschl_tk__=pmd_dJfU3C0J1gqjPJu564MFh5XV7BYtMb.zTazbizQagIk-1635258534-0-gqNtZGzNAiWjcnBszQ0R
 authors:

--- a/SMASH/pages/blog/index.vue
+++ b/SMASH/pages/blog/index.vue
@@ -1,43 +1,49 @@
 <template>
   <div>
-    <basic-page-template
-    >
+    <basic-page-template>
       <template #title>
-        <h2 class="max-w-4xl mx-auto text-2xl font-bold tracking-wide md:text-4xl">
+        <h2
+          class="max-w-4xl mx-auto text-2xl font-bold tracking-wide md:text-4xl"
+        >
           <vue-math-jax :formula="content.title"></vue-math-jax>
         </h2>
       </template>
-    <ul
-        class="pb-5 space-y-6 overflow-visible md:px-0"
-      >
+      <ul class="pb-5 space-y-6 overflow-visible md:px-0">
         <li
           v-for="project in posts"
           :key="project.title"
           class="flex flex-col items-center justify-start w-full"
         >
-            <horizontal-card
-              class="md:w-3/4"
-              :image="project.image"
-              :image-alt="project.imageAlt || ''"
-              :link="project.path"
+          <horizontal-card
+            class="bg-gray-100 shadow-md md:w-3/4"
+            :image="project.image"
+            :image-alt="project.imageAlt || ''"
+            :link="project.path"
+          >
+            <div
+              class="flex flex-col items-center justify-center w-full h-full space-y-2"
             >
-                <div class="flex flex-col items-center justify-center w-full h-full space-y-2">
-                    <p class="w-full text-xs text-left text-gray-500 md:text-base">
-                        {{ new Date(project.date).toLocaleDateString() }}
-                    </p>
-                    <p class="w-full text-base font-medium leading-tight text-left flex-grow-1 lg:text-xl md:text-lg">
-                        {{project.title}}
-                    </p>
-                    <div v-if="project.authors" class="flex flex-col items-center justify-start space-y-3 md:space-y-0 md:space-x-3 md:w-full md:flex-row">
-                        <Pill
-                            v-for="author in project.authors"
-                            :key="author"
-                            :text="author"
-                            color="bg-gray-500"
-                        />
-                    </div>
-                </div>
-            </horizontal-card>
+              <p class="w-full text-xs text-left text-gray-500 md:text-base">
+                {{ new Date(project.date).toLocaleDateString() }}
+              </p>
+              <p
+                class="w-full text-base font-medium leading-tight text-left flex-grow-1 lg:text-xl md:text-lg"
+              >
+                {{ project.title }}
+              </p>
+              <div
+                v-if="project.authors"
+                class="flex flex-col items-center justify-start space-y-3 md:space-y-0 md:space-x-3 md:w-full md:flex-row"
+              >
+                <Pill
+                  v-for="author in project.authors"
+                  :key="author"
+                  :text="author"
+                  color="bg-gray-500"
+                />
+              </div>
+            </div>
+          </horizontal-card>
         </li>
       </ul>
     </basic-page-template>
@@ -47,14 +53,14 @@
 <script>
 import BasicPageTemplate from '@/components/basicPageTemplate.vue'
 import Pill from '@/components/Pill'
-import VueMathJax from "@/components/VueMathJax.vue"
+import VueMathJax from '@/components/VueMathJax.vue'
 import HorizontalCard from '~/components/Cards/HorizontalCard.vue'
 export default {
   components: {
     BasicPageTemplate,
     HorizontalCard,
     Pill,
-    VueMathJax
+    VueMathJax,
   },
   layout: 'header-footer',
   async asyncData({ $content }) {
@@ -62,7 +68,7 @@ export default {
     const content = await $content('overview/blog').fetch()
     return {
       posts,
-      content
+      content,
     }
   },
 }

--- a/SMASH/pages/overview/team.vue
+++ b/SMASH/pages/overview/team.vue
@@ -20,7 +20,7 @@
               class="object-contain w-full h-full"
               :src="imageLink(person.image)"
               :alt="`Photo of ${person.name}`"
-              quality="50"
+              quality="30"
             />
           </div>
           <div class="w-full space-y-2 text-center">

--- a/SMASH/pages/projects/index.vue
+++ b/SMASH/pages/projects/index.vue
@@ -1,23 +1,18 @@
 <template>
   <div>
-    <basic-page-template
-      title="Projects"
-    >
-    <ul
-        class="px-3 pb-5 space-y-6 overflow-visible md:px-0"
-      >
+    <basic-page-template title="Projects">
+      <ul class="px-3 pb-5 space-y-6 overflow-visible md:px-0">
         <li
           v-for="project in projects"
           :key="project.title"
           class="flex flex-col items-center justify-start w-full"
         >
-            <horizontal-card
-              class="w-full md:w-3/4"
-              :icon="project.icon"
-              :text="project.title"
-              :link="project.path"
-            />
-          
+          <horizontal-card
+            class="w-full bg-gray-100 shadow-md md:w-3/4"
+            :icon="project.icon"
+            :text="project.title"
+            :link="project.path"
+          />
         </li>
       </ul>
     </basic-page-template>
@@ -30,7 +25,7 @@ import HorizontalCard from '~/components/Cards/HorizontalCard.vue'
 export default {
   components: {
     BasicPageTemplate,
-    HorizontalCard
+    HorizontalCard,
   },
   layout: 'header-footer',
   async asyncData({ $content }) {

--- a/SMASH/pages/resources/publications.vue
+++ b/SMASH/pages/resources/publications.vue
@@ -39,10 +39,10 @@
                 >Code</a
               >
               <a
-                v-if="publication.prepend"
-                :href="publication.prepend"
+                v-if="publication.preprint"
+                :href="publication.preprint"
                 class="p-2 hover:text-indigo-600"
-                >Prepend</a
+                >Preprint</a
               >
               <a :href="publication.link" class="p-2 hover:text-indigo-600"
                 >Read More</a

--- a/SMASH/static/admin/config.yml
+++ b/SMASH/static/admin/config.yml
@@ -252,8 +252,13 @@ collections:
         required: false
         media_folder: '/static/files'
       - { label: 'Link', name: 'link', widget: 'string' }
-      - { label: 'Code', name: 'code', widget: 'string' }
-      - { label: 'Prepend', name: 'prepend', widget: 'string' }
+      - { label: 'Code', name: 'code', widget: 'string', required: false }
+      - {
+          label: 'Preprint',
+          name: 'preprint',
+          widget: 'string',
+          required: false,
+        }
       - label: 'Author(s)'
         name: 'authors'
         widget: 'list'


### PR DESCRIPTION
- `prepend` --> `preprint`
- `preprint` & `code` now optional
- increased image compression 50% --> 70%
- footer links open in new tab (closes #85)
- hide individual projects in mobile nav menu
- prop typo fix